### PR TITLE
treewide: newAM -> stm32-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stm32wlxx-hal
 
-[![CI](https://github.com/newAM/stm32wlxx-hal/workflows/CI/badge.svg)](https://github.com/newAM/stm32wlxx-hal/actions?query=branch%3Amain)
-[![docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://newam.github.io/stm32wlxx-hal/stm32wlxx_hal/index.html)
+[![CI](https://github.com/stm32-rs/stm32wlxx-hal/workflows/CI/badge.svg)](https://github.com/stm32-rs/stm32wlxx-hal/actions?query=branch%3Amain)
+[![docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://stm32-rs.github.io/stm32wlxx-hal/stm32wlxx_hal/index.html)
 
 Embedded rust HAL (hardware abstraction layer) for the STM32WL series.
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wlxx-hal"
+repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
 stm32wl5x_cm0p = ["stm32wl/stm32wl5x_cm0p"]

--- a/hal/README.md
+++ b/hal/README.md
@@ -7,7 +7,7 @@ Until then please pin the version you use.
 
 ```toml
 [dependencies.stm32wlxx-hal]
-git = "https://github.com/newAM/stm32wlxx-hal.git"
+git = "https://github.com/stm32-rs/stm32wlxx-hal.git"
 rev = "" # put a specific git commit hash here
 features = [
     # use exactly one of the following depending on your target hardware
@@ -97,5 +97,5 @@ this is not consistent (see [#78])
 
 [stm32-rs]: https://github.com/stm32-rs/stm32-rs
 [svd2rust]: https://github.com/rust-embedded/svd2rust
-[#78]: https://github.com/newAM/stm32wlxx-hal/issues/78
-[#149]: https://github.com/newAM/stm32wlxx-hal/issues/149
+[#78]: https://github.com/stm32-rs/stm32wlxx-hal/issues/78
+[#149]: https://github.com/stm32-rs/stm32wlxx-hal/issues/149

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -357,7 +357,7 @@ pub trait Exti {
     ///
     /// See [`gpio-button-irq.rs`].
     ///
-    /// [`gpio-button-irq.rs`]: https://github.com/newAM/stm32wlxx-hal/blob/main/examples/examples/gpio-button-irq.rs
+    /// [`gpio-button-irq.rs`]: https://github.com/stm32-rs/stm32wlxx-hal/blob/main/examples/examples/gpio-button-irq.rs
     fn clear_exti();
 
     /// Setup an input pin as an EXTI interrupt source on core 1.

--- a/lora-e5-bsp/Cargo.toml
+++ b/lora-e5-bsp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "bsp", "seeed"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wlxx-hal"
+repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
 defmt = ["stm32wlxx-hal/defmt"]

--- a/nucleo-wl55jc-bsp/Cargo.toml
+++ b/nucleo-wl55jc-bsp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "bsp", "nucleo"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wlxx-hal"
+repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
 defmt = ["stm32wlxx-hal/defmt"]

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -76,4 +76,4 @@ $ cargo test -p testsuite --target thumbv7em-none-eabi --bin subghz -- --probe 0
 [newAM/probe-run]: https://github.com/newAM/probe-run
 [probe-run]: https://github.com/knurling-rs/probe-run
 [rustup]: https://rustup.rs/
-[#74]: https://github.com/newAM/stm32wlxx-hal/issues/74
+[#74]: https://github.com/stm32-rs/stm32wlxx-hal/issues/74


### PR DESCRIPTION
Update URLs after moving this repo to the stm32-rs org.