### PR TITLE
subghz: fix timeouts after calling set_sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed timeouts after calling `SubGhz::set_sleep`.
+
 ## [0.2.0] - 2021-11-11
 ### Added
 - Added two board support crates

--- a/hal/src/subghz/mod.rs
+++ b/hal/src/subghz/mod.rs
@@ -788,7 +788,14 @@ where
     /// # Ok::<(), stm32wlxx_hal::subghz::Error>(())
     /// ```
     pub unsafe fn set_sleep(&mut self, cfg: SleepCfg) -> Result<(), Error> {
-        self.write(&[OpCode::SetSleep as u8, u8::from(cfg)])
+        // poll for busy before, but not after
+        // radio idles with busy high while in sleep mode
+        self.poll_not_busy();
+        {
+            let _nss: Nss = Nss::new();
+            self.spi.write(&[OpCode::SetSleep as u8, u8::from(cfg)])?;
+        }
+        Ok(())
     }
 
     /// Put the radio into standby mode.


### PR DESCRIPTION
See https://github.com/newAM/stm32wl-lightswitch-demo/issues/25