### PR TITLE
treewide: add license to unpublished crates

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 authors = ["Alex Martens <alexmgit@protonmail.com>"]
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 defmt = "0.3"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -7,6 +7,7 @@ name = "testsuite"
 publish = false
 edition = "2021"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [[bin]]
 name = "adc"


### PR DESCRIPTION
This makes the workspace easier to audit with `cargo license`.