### PR TITLE
README: update probe-run instructions

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -3,7 +3,7 @@ name = "stm32wlxx-hal"
 description = "Hardware abstraction layer for the STM32WL series microcontrollers."
 readme = "../README.md"
 
-version = "0.2.1"  # update BSP versions, BSP HAL depdendency version, and README
+version = "0.2.1"  # update BSP versions, BSP HAL depdendency version, README, and BSP READMEs
 authors = ["Alex Martens <alexmgit@protonmail.com>"]
 edition = "2021"
 rust-version = "1.56"  # update MSRV in CI, BSPs, and shield in README

--- a/lora-e5-bsp/README.md
+++ b/lora-e5-bsp/README.md
@@ -4,6 +4,19 @@ Board support for the seeed LoRa-E5 development kit.
 
 This crate extends the [stm32wlxx-hal] with board specific hardware, see that crate for more information.
 
+## Usage
+
+```toml
+[dependencies.lora-e5-bsp]
+version = "0.2.1"
+features = [
+    # optional: use the cortex-m-rt interrupt interface
+    "rt",
+    # optional: use defmt
+    "defmt",
+]
+```
+
 ## Flashing
 
 This board is a pain to get working for the first time because the flash protection bits are set.
@@ -15,7 +28,10 @@ Check these resources to unlock the board for programming:
 
 To flash this board with various rust utilities such as `probe-run`, `cargo-embed`, and `cargo-flash` remove the `--connected-under-reset` flag. This flag is required for the NUCLEO board, but will cause timeout errors with the LoRa-E5 development board.
 
-Flashing binaries larger than 64k with `probe-rs` based tools will hard fault, see [#74] for more information.
+⚠️ You must use recent versions of `probe-rs` based tools to avoid bugs with the STM32WL ⚠️
+
+* `cargo-embed` >=0.12.0
+* `cargo-flash` >=0.12.0
+* `probe-run` >=0.3.1
 
 [stm32wlxx-hal]: https://github.com/stm32-rs/stm32wlxx-hal
-[#74]: https://github.com/stm32-rs/stm32wlxx-hal/issues/74

--- a/nucleo-wl55jc-bsp/README.md
+++ b/nucleo-wl55jc-bsp/README.md
@@ -4,11 +4,30 @@ Board support for the NUCLEO-WL55JC development board.
 
 This crate extends the [stm32wlxx-hal] with board specific hardware, see that crate for more information.
 
+## Usage
+
+```toml
+[dependencies.nucleo-wl55jc-bsp]
+version = "0.2.1"
+features = [
+    # required: build for core 1
+    # This is future proofing for when the HAL has APIs for core 2
+    "stm32wl5x_cm4",
+    # optional: use the cortex-m-rt interrupt interface
+    "rt",
+    # optional: use defmt
+    "defmt",
+]
+```
+
 ## Flashing
 
 To flash this board with various rust utilities such as `probe-run`, `cargo-embed`, and `cargo-flash` use the `--connected-under-reset` flag.
 
-Flashing binaries larger than 64k with `probe-rs` based tools will hard fault, see [#74] for more information.
+⚠️ You must use recent versions of `probe-rs` based tools to avoid bugs with the STM32WL ⚠️
+
+* `cargo-embed` >=0.12.0
+* `cargo-flash` >=0.12.0
+* `probe-run` >=0.3.1
 
 [stm32wlxx-hal]: https://github.com/stm32-rs/stm32wlxx-hal
-[#74]: https://github.com/stm32-rs/stm32wlxx-hal/issues/74

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -10,15 +10,16 @@ These tests will run automatically as part of CI for every pull-request.
 ## Quickstart
 
 * `rustup target add --toolchain stable thumbv7m-none-eabi` ([rustup])
-* `cargo install --git https://github.com/newAM/probe-run.git`
-  ([probe-run], [newAM/probe-run])
-    * **Note:** My fork contains unreleased fixes for the stm32wl,
-      see [#74] for details.
-* Linux users: Add udev rules then run `sudo udevadm control --reload-rules && sudo udevadm trigger`
+* `cargo install probe-run` ([probe-run])
+  * ⚠️ You must use version >=0.3.1 to avoid bugs with the STM32WL ⚠️
+* Linux users: Add udev rules
+
 ```text
 # /etc/udev/rules.d/99-stm.rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374e", MODE="0666"
 ```
+
+* Linux users: run `sudo udevadm control --reload-rules && sudo udevadm trigger`
 * Connect the nucleo board to your PC via USB
 * `cargo test -p testsuite --target thumbv7em-none-eabi --bin pka`
 
@@ -76,7 +77,5 @@ $ DEFMT_LOG=info cargo test -p testsuite --target thumbv7em-none-eabi --bin subg
 ```
 
 [defmt-test]: https://crates.io/crates/defmt-test
-[newAM/probe-run]: https://github.com/newAM/probe-run
 [probe-run]: https://github.com/knurling-rs/probe-run
 [rustup]: https://rustup.rs/
-[#74]: https://github.com/stm32-rs/stm32wlxx-hal/issues/74


### PR DESCRIPTION
Issues with the STM32WL + probe-rs tools have been resolved.
This removes references to my patched fork of probe-run.