### PR TITLE
embedded-time: move to a non-default feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     env: {"RUSTFLAGS": "-D warnings"}
     strategy:
       matrix:
-        feature:
+        mcu:
           - "stm32wl5x_cm0p"
           - "stm32wl5x_cm4"
           - "stm32wle5"
@@ -139,17 +139,17 @@ jobs:
           toolchain: stable
 
       - name: Test HAL
-        run: cargo test --features ${{ matrix.feature }}
+        run: cargo test --features ${{ matrix.mcu }},embedded-time
 
       - name: Test nucleo BSP
         if: ${{ startsWith(matrix.mcu, 'stm32wl5x') }}
         run: |
-          cargo test -p nucleo-wl55jc-bsp --features ${{ matrix.feature }}
+          cargo test -p nucleo-wl55jc-bsp --features ${{ matrix.mcu }},embedded-time
 
       - name: Test LoRa E5 BSP
         if: ${{ matrix.mcu == 'stm32wle5' }}
         run: |
-          cargo test -p lora-e5-bsp --features ${{ matrix.feature }}
+          cargo test -p lora-e5-bsp --features ${{ matrix.mcu }},embedded-time
 
   clippy:
     name: Clippy
@@ -203,7 +203,7 @@ jobs:
         run: |
           cd hal
           cargo +nightly rustdoc \
-          --features rt,stm32wl5x_cm4 \
+          --features embedded-time,rt,stm32wl5x_cm4 \
           -- -Z unstable-options --enable-index-page
       - name: deploy
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,7 @@ jobs:
 
       - name: Test LoRa E5 BSP
         if: ${{ matrix.mcu == 'stm32wle5' }}
-        run: |
-          cargo test -p lora-e5-bsp --features ${{ matrix.mcu }},embedded-time
+        run: cargo test -p lora-e5-bsp --features embedded-time
 
   clippy:
     name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `info::UID64`
   - Moved to `info::Uid64::PTR`.
   - Changed the type from `*const u8` to `*const u32`.
-- Moved `info::uid64` to `info::Uid64::from_device`.
-- Moved `info::uid64_devnum` to `info::Uid64::read_devnum`.
-- Moved `info::package` to `info::Package::from_device`.
-- Moved `info::uid` to `info::Uid::from_device`.
+- Moved functions in `info` into the associated structs/enums.
+  - Moved `info::uid64` to `info::Uid64::from_device`.
+  - Moved `info::uid64_devnum` to `info::Uid64::read_devnum`.
+  - Moved `info::package` to `info::Package::from_device`.
+  - Moved `info::uid` to `info::Uid::from_device`.
 - Added `#[inline]` to `util::new_delay` and `util::reset_cycle_count`.
+- `embedded-time` is now an optional feature.
+  - Changed `I2C::new` to use `u32` instead of `embedded_time::Hertz`.
 
 ## [0.2.1] - 2021-11-20
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ features = [
     "rt",
     # optional: use defmt
     "defmt",
+    # optional: enable conversions with embedded-time types
+    "embedded-time",
 ]
 ```
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -25,7 +25,7 @@ cortex-m = "0.7.2"
 cortex-m-rt = { version = "0.7", optional = true }
 defmt = { version = "0.3", optional = true }
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
-embedded-time = "0.12"
+embedded-time = { version = "0.12", optional = true }
 nb = "1"
 num-traits = { version = "0.2", default-features = false }
 paste = "1"

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -38,5 +38,5 @@ static_assertions = "1"
 
 [package.metadata.docs.rs]
 all-features = false
-features = ["stm32wl5x_cm4", "rt"]
+features = ["stm32wl5x_cm4", "rt", "embedded-time"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -74,4 +74,6 @@ pub use cortex_m_rt;
 pub use chrono;
 pub use cortex_m;
 pub use embedded_hal;
+
+#[cfg(feature = "embedded_time")]
 pub use embedded_time;

--- a/hal/src/subghz/timeout.rs
+++ b/hal/src/subghz/timeout.rs
@@ -412,18 +412,21 @@ impl From<Timeout> for [u8; 3] {
     }
 }
 
+#[cfg(feature = "embedded_time")]
 impl From<Timeout> for embedded_time::duration::Seconds {
     fn from(to: Timeout) -> Self {
         embedded_time::duration::Seconds(to.as_secs().into())
     }
 }
 
+#[cfg(feature = "embedded_time")]
 impl From<Timeout> for embedded_time::duration::Milliseconds {
     fn from(to: Timeout) -> Self {
         embedded_time::duration::Milliseconds(to.as_millis())
     }
 }
 
+#[cfg(feature = "embedded_time")]
 impl From<Timeout> for embedded_time::duration::Microseconds {
     fn from(to: Timeout) -> Self {
         embedded_time::duration::Microseconds(to.as_micros())

--- a/hal/src/subghz/tx_params.rs
+++ b/hal/src/subghz/tx_params.rs
@@ -44,6 +44,7 @@ impl From<RampTime> for core::time::Duration {
     }
 }
 
+#[cfg(feature = "embedded_time")]
 impl From<RampTime> for embedded_time::duration::Microseconds {
     fn from(rt: RampTime) -> Self {
         match rt {

--- a/lora-e5-bsp/Cargo.toml
+++ b/lora-e5-bsp/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
 defmt = ["stm32wlxx-hal/defmt", "dfmt"]
+embedded-time = ["stm32wlxx-hal/embedded-time"]
 rt = ["stm32wlxx-hal/rt"]
 
 [dependencies.stm32wlxx-hal]

--- a/lora-e5-bsp/Cargo.toml
+++ b/lora-e5-bsp/Cargo.toml
@@ -26,3 +26,8 @@ features = ["stm32wle5"]
 package = "defmt"
 version = "0.3"
 optional = true
+
+[package.metadata.docs.rs]
+all-features = false
+features = ["rt", "embedded-time"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/lora-e5-bsp/README.md
+++ b/lora-e5-bsp/README.md
@@ -14,6 +14,8 @@ features = [
     "rt",
     # optional: use defmt
     "defmt",
+    # optional: enable conversions with embedded-time types
+    "embedded-time",
 ]
 ```
 

--- a/nucleo-wl55jc-bsp/Cargo.toml
+++ b/nucleo-wl55jc-bsp/Cargo.toml
@@ -27,3 +27,8 @@ path = "../hal"
 package = "defmt"
 version = "0.3"
 optional = true
+
+[package.metadata.docs.rs]
+all-features = false
+features = ["stm32wl5x_cm4", "rt", "embedded-time"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/nucleo-wl55jc-bsp/Cargo.toml
+++ b/nucleo-wl55jc-bsp/Cargo.toml
@@ -14,9 +14,10 @@ repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
 defmt = ["stm32wlxx-hal/defmt", "dfmt"]
+embedded-time = ["stm32wlxx-hal/embedded-time"]
 rt = ["stm32wlxx-hal/rt"]
-stm32wl5x_cm4 = ["stm32wlxx-hal/stm32wl5x_cm4"]
 stm32wl5x_cm0p = ["stm32wlxx-hal/stm32wl5x_cm0p"]
+stm32wl5x_cm4 = ["stm32wlxx-hal/stm32wl5x_cm4"]
 
 [dependencies.stm32wlxx-hal]
 version = "=0.2.1"

--- a/nucleo-wl55jc-bsp/README.md
+++ b/nucleo-wl55jc-bsp/README.md
@@ -17,6 +17,8 @@ features = [
     "rt",
     # optional: use defmt
     "defmt",
+    # optional: enable conversions with embedded-time types
+    "embedded-time",
 ]
 ```
 

--- a/testsuite/src/i2c.rs
+++ b/testsuite/src/i2c.rs
@@ -3,7 +3,6 @@
 
 use defmt::unwrap;
 use defmt_rtt as _; // global logger
-use embedded_time::rate::Hertz;
 use nucleo_wl55jc_bsp::hal::{
     cortex_m,
     embedded_hal::blocking::i2c::WriteRead,
@@ -36,7 +35,7 @@ mod tests {
             let i2c2 = I2c2::new(
                 dp.I2C2,
                 (gpioa.a12, gpioa.a11),
-                Hertz(I2C_FREQUENCY),
+                I2C_FREQUENCY,
                 &mut dp.RCC,
                 true,
                 cs,
@@ -72,7 +71,7 @@ mod tests {
             I2c1::new(
                 dp.I2C1,
                 (gpiob.b8, gpiob.b7),
-                Hertz(I2C_FREQUENCY),
+                I2C_FREQUENCY,
                 &mut dp.RCC,
                 false,
                 cs,


### PR DESCRIPTION
This reduces the compile time from 17.6s to 16.2s when not used.