### PR TITLE
chrono: move to a non-default feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,7 +29,7 @@ test-subghz = "test -p testsuite --target thumbv7em-none-eabi --bin subghz"
 test-uart = "test -p testsuite --target thumbv7em-none-eabi --bin uart"
 
 # e.g. cargo unit
-unit = "test --features stm32wl5x_cm4"
-unit-little = "test --features stm32wl5x_cm0p"
+unit = "test --features stm32wl5x_cm4,chrono,embedded-time"
+unit-little = "test --features stm32wl5x_cm0p,chrono,embedded-time"
 unit-nucleo = "test -p nucleo-wl55jc-bsp --features stm32wl5x_cm4"
 unit-lora-e5 = "test -p lora-e5-bsp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,16 +139,16 @@ jobs:
           toolchain: stable
 
       - name: Test HAL
-        run: cargo test --features ${{ matrix.mcu }},embedded-time
+        run: cargo test --features ${{ matrix.mcu }},embedded-time,chrono
 
       - name: Test nucleo BSP
         if: ${{ startsWith(matrix.mcu, 'stm32wl5x') }}
         run: |
-          cargo test -p nucleo-wl55jc-bsp --features ${{ matrix.mcu }},embedded-time
+          cargo test -p nucleo-wl55jc-bsp --features ${{ matrix.mcu }},embedded-time,chrono
 
       - name: Test LoRa E5 BSP
         if: ${{ matrix.mcu == 'stm32wle5' }}
-        run: cargo test -p lora-e5-bsp --features embedded-time
+        run: cargo test -p lora-e5-bsp --features embedded-time,chrono
 
   clippy:
     name: Clippy
@@ -202,7 +202,7 @@ jobs:
         run: |
           cd hal
           cargo +nightly rustdoc \
-          --features embedded-time,rt,stm32wl5x_cm4 \
+          --features chrono,embedded-time,rt,stm32wl5x_cm4 \
           -- -Z unstable-options --enable-index-page
       - name: deploy
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    "rust-analyzer.cargo.features": ["stm32wl5x_cm4", "rt"],
+    "rust-analyzer.cargo.features": ["stm32wl5x_cm4", "rt", "chrono"],
     "rust-analyzer.cargo.allFeatures": false,
-    "rust-analyzer.checkOnSave.features": ["stm32wl5x_cm4", "rt"],
+    "rust-analyzer.checkOnSave.features": ["stm32wl5x_cm4", "rt", "chrono"],
     "rust-analyzer.checkOnSave.allFeatures": false,
     "rust-analyzer.checkOnSave.allTargets": false,
     "rust-analyzer.cargo.target": "thumbv7em-none-eabi",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved `info::package` to `info::Package::from_device`.
   - Moved `info::uid` to `info::Uid::from_device`.
 - Added `#[inline]` to `util::new_delay` and `util::reset_cycle_count`.
-- `embedded-time` is now an optional feature.
-  - Changed `I2C::new` to use `u32` instead of `embedded_time::Hertz`.
+- Large dependencies are now optional.
+  - `embedded-time` is now an optional feature.
+    - Changed `I2C::new` to use `u32` instead of `embedded_time::Hertz`.
+  - `chrono` is not an optional feature.
 
 ## [0.2.1] - 2021-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Large dependencies are now optional.
   - `embedded-time` is now an optional feature.
     - Changed `I2C::new` to use `u32` instead of `embedded_time::Hertz`.
-  - `chrono` is not an optional feature.
+  - `chrono` is now an optional feature.
 
 ## [0.2.1] - 2021-11-20
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ features = [
     "defmt",
     # optional: enable conversions with embedded-time types
     "embedded-time",
+    # optional: use the real time clock (RTC)
+    "chrono",
 ]
 ```
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -20,7 +20,7 @@ rt = ["stm32wl/rt", "cortex-m-rt"]
 
 [dependencies]
 cfg-if = "1"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, optional = true }
 cortex-m = "0.7.2"
 cortex-m-rt = { version = "0.7", optional = true }
 defmt = { version = "0.3", optional = true }
@@ -38,5 +38,5 @@ static_assertions = "1"
 
 [package.metadata.docs.rs]
 all-features = false
-features = ["stm32wl5x_cm4", "rt", "embedded-time"]
+features = ["stm32wl5x_cm4", "rt", "embedded-time", "chrono"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -59,6 +59,7 @@ pub mod pka;
 pub mod pwr;
 pub mod rcc;
 pub mod rng;
+#[cfg(feature = "chrono")]
 pub mod rtc;
 pub mod spi;
 pub mod subghz;
@@ -71,6 +72,7 @@ pub use ratio::Ratio;
 #[cfg(feature = "rt")]
 pub use cortex_m_rt;
 
+#[cfg(feature = "chrono")]
 pub use chrono;
 pub use cortex_m;
 pub use embedded_hal;

--- a/lora-e5-bsp/Cargo.toml
+++ b/lora-e5-bsp/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
+chrono = ["stm32wlxx-hal/chrono"]
 defmt = ["stm32wlxx-hal/defmt", "dfmt"]
 embedded-time = ["stm32wlxx-hal/embedded-time"]
 rt = ["stm32wlxx-hal/rt"]
@@ -29,5 +30,5 @@ optional = true
 
 [package.metadata.docs.rs]
 all-features = false
-features = ["rt", "embedded-time"]
+features = ["rt", "embedded-time", "chrono"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/lora-e5-bsp/README.md
+++ b/lora-e5-bsp/README.md
@@ -16,6 +16,8 @@ features = [
     "defmt",
     # optional: enable conversions with embedded-time types
     "embedded-time",
+    # optional: use the real time clock (RTC)
+    "chrono",
 ]
 ```
 

--- a/nucleo-wl55jc-bsp/Cargo.toml
+++ b/nucleo-wl55jc-bsp/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 repository = "https://github.com/stm32-rs/stm32wlxx-hal"
 
 [features]
+chrono = ["stm32wlxx-hal/chrono"]
 defmt = ["stm32wlxx-hal/defmt", "dfmt"]
 embedded-time = ["stm32wlxx-hal/embedded-time"]
 rt = ["stm32wlxx-hal/rt"]
@@ -30,5 +31,5 @@ optional = true
 
 [package.metadata.docs.rs]
 all-features = false
-features = ["stm32wl5x_cm4", "rt", "embedded-time"]
+features = ["stm32wl5x_cm4", "rt", "embedded-time", "chrono"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/nucleo-wl55jc-bsp/README.md
+++ b/nucleo-wl55jc-bsp/README.md
@@ -19,6 +19,8 @@ features = [
     "defmt",
     # optional: enable conversions with embedded-time types
     "embedded-time",
+    # optional: use the real time clock (RTC)
+    "chrono",
 ]
 ```
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -88,8 +88,11 @@ embedded-time = "0.12"
 hex-literal = "0.3"
 itertools = { version = "0.10", default-features = false }
 nb = "1"
-nucleo-wl55jc-bsp = { path = "../nucleo-wl55jc-bsp", features = ["stm32wl5x_cm4", "defmt", "rt"] }
 panic-probe = { version = "0.3", features = ["print-defmt" ] }
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 static_assertions = "1"
+
+[dependencies.nucleo-wl55jc-bsp]
+path = "../nucleo-wl55jc-bsp"
+features = ["stm32wl5x_cm4", "defmt", "rt", "chrono"]


### PR DESCRIPTION
This reduces the compile time from 16.2s to 15.2s when not used.