### PR TITLE
Fix/uart clock

### DIFF
--- a/hal/src/rcc.rs
+++ b/hal/src/rcc.rs
@@ -692,7 +692,7 @@ fn cpu1_systick(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R, src: SystClkSource) ->
     }
 }
 
-fn pclk1(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
+pub(crate) fn pclk1(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
     let div: u32 = ppre_div(cfgr.ppre1().bits()).into();
     hclk1(rcc, cfgr) / div
 }

--- a/hal/src/uart.rs
+++ b/hal/src/uart.rs
@@ -232,7 +232,7 @@ impl_consts!(Uart1, 17, 18, UART1_BASE);
 impl_consts!(Uart2, 19, 20, UART2_BASE);
 
 macro_rules! impl_clock_hz {
-    ($uart:ident, $sel:ident, $presc:ident, $method:ident) => {
+    ($uart:ident, $sel:ident, $presc:ident, $method:ident, $pclk_method:ident) => {
         impl<RX, TX> $uart<RX, TX> {
             /// Calculate the clock frequency.
             ///
@@ -242,7 +242,7 @@ macro_rules! impl_clock_hz {
                 let src: Ratio<u32> = match rcc.ccipr.read().$method().variant() {
                     $sel::PCLK => {
                         let cfgr: pac::rcc::cfgr::R = rcc.cfgr.read();
-                        rcc::hclk3(rcc, &cfgr)
+                        rcc::$pclk_method(rcc, &cfgr)
                     }
                     $sel::SYSCLK => {
                         let cfgr: pac::rcc::cfgr::R = rcc.cfgr.read();
@@ -274,9 +274,9 @@ macro_rules! impl_clock_hz {
     };
 }
 
-impl_clock_hz!(LpUart, LPUART1SEL_A, lpuart, lpuart1sel);
-impl_clock_hz!(Uart1, USART1SEL_A, usart1, usart1sel);
-impl_clock_hz!(Uart2, USART1SEL_A, usart1, usart2sel);
+impl_clock_hz!(LpUart, LPUART1SEL_A, lpuart, lpuart1sel, pclk1);
+impl_clock_hz!(Uart1, USART1SEL_A, usart1, usart1sel, pclk2);
+impl_clock_hz!(Uart2, USART1SEL_A, usart1, usart2sel, pclk1);
 
 macro_rules! impl_pulse_reset {
     ($uart:ident, $reg:ident, $method:ident) => {


### PR DESCRIPTION
Fixes #292 by adding an extra parameter to the macro `impl_clock_hz`.

Tested for UART1 with PClk as HClk/4, at 9600 bauds.

I will try to issue another PR to update the test suite but I won't have much time until next month.