### PR TITLE
Cargo.toml: use resolver version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "*-bsp",
     "examples",


### PR DESCRIPTION
Virtual workspaces still need to set this manually, even when using
edition 2021.