### PR TITLE
Address spelling issues of Available and Tcxo.

### DIFF
--- a/.config/lingo.dic
+++ b/.config/lingo.dic
@@ -122,7 +122,6 @@ TCXO
 timestamp
 Timestamp
 tuple
-TXCO
 UART
 UFBGA73
 UFQFPN48

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Renamed function TcxoMode::set_txco_trim() to TcxoMode::set_tcxo_trim() to correct spelling.
+- Renamed enum CmdStatus::Avaliable to CmdStatus::Available to correct spelling.
 - Updated minimum `chrono` version to `0.4.23` to satisfy `cargo-audit`.
 - Changed minimum supported rust version from 1.60 to 1.62.
 

--- a/hal/src/adc.rs
+++ b/hal/src/adc.rs
@@ -825,7 +825,7 @@ impl Adc {
     /// ```
     #[inline]
     pub fn set_isr(&mut self, isr: u32) {
-        // saftey: reserved bits are masked and will be held at reset value
+        // safety: reserved bits are masked and will be held at reset value
         self.adc.isr.write(|w| unsafe { w.bits(isr & irq::ALL) })
     }
 
@@ -848,7 +848,7 @@ impl Adc {
     /// ```
     #[inline]
     pub fn isr() -> pac::adc::isr::R {
-        // saftey: atomic read with no side-effects
+        // safety: atomic read with no side-effects
         unsafe { (*pac::ADC::PTR).isr.read() }
     }
 
@@ -870,7 +870,7 @@ impl Adc {
     /// ```
     #[inline]
     pub fn set_ier(&mut self, ier: u32) {
-        // saftey: reserved bits are masked and will be held at reset value
+        // safety: reserved bits are masked and will be held at reset value
         self.adc.ier.write(|w| unsafe { w.bits(ier & irq::ALL) })
     }
 
@@ -909,7 +909,7 @@ impl Adc {
     pub fn start_chsel(&mut self, ch: u32) {
         debug_assert!(self.adc.cr.read().adstart().is_not_active());
         // See section 18.3.8 page 542 "Channel selection"
-        // saftey: reserved bits are masked and will be held at reset value
+        // safety: reserved bits are masked and will be held at reset value
         self.adc
             .chselr0()
             .write(|w| unsafe { w.chsel().bits(ch & CH_MASK) });

--- a/hal/src/dma/cr.rs
+++ b/hal/src/dma/cr.rs
@@ -280,7 +280,7 @@ impl Cr {
     /// ```
     ///
     /// [`enabled`]: crate::dma::Cr::enabled
-    #[must_use = "set_secm returns a modified Cr"]
+    #[must_use = "set_secure returns a modified Cr"]
     pub const fn set_secure(mut self, sec: bool) -> Cr {
         if sec {
             self.val |= 1 << 17;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -16,7 +16,7 @@
     all(feature = "stm32wl5x_cm4", feature = "stm32wle5"),
 ))]
 compile_error!(
-    "Multile chip features activated. \
+    "Multiple chip features activated. \
     You must activate exactly one of the following features: \
     stm32wl5x_cm0p, stm32wl5x_cm4, stm32wle5"
 );

--- a/hal/src/rtc/mod.rs
+++ b/hal/src/rtc/mod.rs
@@ -218,14 +218,14 @@ impl Rtc {
     /// Read the RTC status (interrupt) register.
     #[inline]
     pub fn status() -> pac::rtc::sr::R {
-        // saftey: atomic read with no side-effects
+        // safety: atomic read with no side-effects
         unsafe { (*pac::RTC::PTR).sr.read() }
     }
 
     /// Read the RTC masked status (interrupt) register.
     #[inline]
     pub fn masked_status() -> pac::rtc::misr::R {
-        // saftey: atomic read with no side-effects
+        // safety: atomic read with no side-effects
         unsafe { (*pac::RTC::PTR).misr.read() }
     }
 

--- a/hal/src/subghz/mod.rs
+++ b/hal/src/subghz/mod.rs
@@ -188,7 +188,7 @@ pub fn mask_irq() {
 /// details.
 #[inline]
 pub fn rfbusys() -> bool {
-    // safety: atmoic read with no side-effects
+    // safety: atomic read with no side-effects
     unsafe { (*pac::PWR::PTR).sr2.read().rfbusys().is_busy() }
 }
 
@@ -198,7 +198,7 @@ pub fn rfbusys() -> bool {
 /// details.
 #[inline]
 pub fn rfbusyms() -> bool {
-    // saftey: atomic read with no side-effects
+    // safety: atomic read with no side-effects
     unsafe { (*pac::PWR::PTR).sr2.read().rfbusyms().is_busy() }
 }
 
@@ -273,7 +273,7 @@ fn pulse_reset(rcc: &mut pac::RCC) {
 /// const TX_PARAMS: TxParams = TxParams::LP_10.set_ramp_time(RampTime::Micros40);
 ///
 /// const TCXO_MODE: TcxoMode = TcxoMode::new()
-///     .set_txco_trim(TcxoTrim::Volts1pt7)
+///     .set_tcxo_trim(TcxoTrim::Volts1pt7)
 ///     .set_timeout(Timeout::from_millis_sat(10));
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
@@ -769,12 +769,12 @@ where
     ///
     /// [`set_rx_duty_cycle`]: crate::subghz::SubGhz::set_rx_duty_cycle
     pub fn set_rtc_period(&mut self, period: Timeout) -> Result<(), Error> {
-        let tobits: u32 = period.into_bits();
+        let to_bits: u32 = period.into_bits();
         self.write(wr_reg![
             RTCPRDR2,
-            (tobits >> 16) as u8,
-            (tobits >> 8) as u8,
-            tobits as u8
+            (to_bits >> 16) as u8,
+            (to_bits >> 8) as u8,
+            to_bits as u8
         ])
     }
 
@@ -907,23 +907,23 @@ where
 
     /// Setup the sub-GHz radio for TX.
     pub fn set_tx(&mut self, timeout: Timeout) -> Result<(), Error> {
-        let tobits: u32 = timeout.into_bits();
+        let to_bits: u32 = timeout.into_bits();
         self.write(&[
             OpCode::SetTx.into(),
-            (tobits >> 16) as u8,
-            (tobits >> 8) as u8,
-            tobits as u8,
+            (to_bits >> 16) as u8,
+            (to_bits >> 8) as u8,
+            to_bits as u8,
         ])
     }
 
     /// Setup the sub-GHz radio for RX.
     pub fn set_rx(&mut self, timeout: Timeout) -> Result<(), Error> {
-        let tobits: u32 = timeout.into_bits();
+        let to_bits: u32 = timeout.into_bits();
         self.write(&[
             OpCode::SetRx.into(),
-            (tobits >> 16) as u8,
-            (tobits >> 8) as u8,
-            tobits as u8,
+            (to_bits >> 16) as u8,
+            (to_bits >> 8) as u8,
+            to_bits as u8,
         ])
     }
 

--- a/hal/src/subghz/mod_params.rs
+++ b/hal/src/subghz/mod_params.rs
@@ -544,7 +544,7 @@ impl FskModParams {
     ///     .set_bandwidth(FskBandwidth::Bw58)
     ///     .set_fdev(FskFdev::from_hertz(10_000));
     ///
-    /// // 30 PPM is wost case (if the HSE32 crystal meets requirements)
+    /// // 30 PPM is worst case (if the HSE32 crystal meets requirements)
     /// sa::const_assert!(MOD_PARAMS.is_valid(30));
     /// ```
     #[must_use = "the return value indicates if the modulation parameters are valid"]
@@ -851,7 +851,7 @@ impl LoRaModParams {
     /// When possible, enabling the low data rate optimization, relaxes the
     /// total frequency drift over the packet time by 16:
     ///
-    /// Freq_drift_optimise_max = 16 × Freq_drift_max
+    /// Freq_drift_optimize_max = 16 × Freq_drift_max
     ///
     /// # Example
     ///

--- a/hal/src/subghz/packet_status.rs
+++ b/hal/src/subghz/packet_status.rs
@@ -30,7 +30,7 @@ impl FskPacketStatus {
     /// let pkt_status: FskPacketStatus = FskPacketStatus::from(example_data_from_radio);
     /// let status: Status = pkt_status.status();
     /// assert_eq!(status.mode(), Ok(StatusMode::Rx));
-    /// assert_eq!(status.cmd(), Ok(CmdStatus::Avaliable));
+    /// assert_eq!(status.cmd(), Ok(CmdStatus::Available));
     /// ```
     pub const fn status(&self) -> Status {
         Status::from_raw(self.buf[0])
@@ -195,7 +195,7 @@ impl LoRaPacketStatus {
     /// let pkt_status: LoRaPacketStatus = LoRaPacketStatus::from(example_data_from_radio);
     /// let status: Status = pkt_status.status();
     /// assert_eq!(status.mode(), Ok(StatusMode::Rx));
-    /// assert_eq!(status.cmd(), Ok(CmdStatus::Avaliable));
+    /// assert_eq!(status.cmd(), Ok(CmdStatus::Available));
     /// ```
     pub const fn status(&self) -> Status {
         Status::from_raw(self.buf[0])

--- a/hal/src/subghz/stats.rs
+++ b/hal/src/subghz/stats.rs
@@ -40,7 +40,7 @@ impl<ModType> Stats<ModType> {
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 0];
     /// let stats: Stats<FskStats> = Stats::from_raw_fsk(example_data_from_radio);
     /// assert_eq!(stats.status().mode(), Ok(StatusMode::Rx));
-    /// assert_eq!(stats.status().cmd(), Ok(CmdStatus::Avaliable));
+    /// assert_eq!(stats.status().cmd(), Ok(CmdStatus::Available));
     /// ```
     pub const fn status(&self) -> Status {
         self.status
@@ -159,7 +159,7 @@ mod test {
         let example_data_from_radio: [u8; 7] = [0x54, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         let stats: Stats<LoRaStats> = Stats::from_raw_lora(example_data_from_radio);
         assert_eq!(stats.status().mode(), Ok(StatusMode::Rx));
-        assert_eq!(stats.status().cmd(), Ok(CmdStatus::Avaliable));
+        assert_eq!(stats.status().cmd(), Ok(CmdStatus::Available));
         assert_eq!(stats.pkt_rx(), 0x0102);
         assert_eq!(stats.pkt_crc(), 0x0304);
         assert_eq!(stats.pkt_hdr_err(), 0x0506);

--- a/hal/src/subghz/status.rs
+++ b/hal/src/subghz/status.rs
@@ -61,7 +61,7 @@ pub enum CmdStatus {
     /// Data available to host.
     ///
     /// Packet received successfully and data can be retrieved.
-    Avaliable = 0x2,
+    Available = 0x2,
     /// Command time out.
     ///
     /// Command took too long to complete triggering a sub-GHz radio watchdog
@@ -91,7 +91,7 @@ impl CmdStatus {
     /// ```
     /// use stm32wlxx_hal::subghz::CmdStatus;
     ///
-    /// assert_eq!(CmdStatus::from_raw(0x2), Ok(CmdStatus::Avaliable));
+    /// assert_eq!(CmdStatus::from_raw(0x2), Ok(CmdStatus::Available));
     /// assert_eq!(CmdStatus::from_raw(0x3), Ok(CmdStatus::Timeout));
     /// assert_eq!(CmdStatus::from_raw(0x4), Ok(CmdStatus::ProcessingError));
     /// assert_eq!(CmdStatus::from_raw(0x5), Ok(CmdStatus::ExecutionFailure));
@@ -101,7 +101,7 @@ impl CmdStatus {
     /// ```
     pub const fn from_raw(bits: u8) -> Result<Self, u8> {
         match bits {
-            0x2 => Ok(CmdStatus::Avaliable),
+            0x2 => Ok(CmdStatus::Available),
             0x3 => Ok(CmdStatus::Timeout),
             0x4 => Ok(CmdStatus::ProcessingError),
             0x5 => Ok(CmdStatus::ExecutionFailure),
@@ -142,7 +142,7 @@ impl Status {
     ///
     /// const STATUS: Status = Status::from_raw(0x54_u8);
     /// assert_eq!(STATUS.mode(), Ok(StatusMode::Rx));
-    /// assert_eq!(STATUS.cmd(), Ok(CmdStatus::Avaliable));
+    /// assert_eq!(STATUS.cmd(), Ok(CmdStatus::Available));
     /// ```
     pub const fn from_raw(value: u8) -> Status {
         Status(value)

--- a/hal/src/subghz/tcxo_mode.rs
+++ b/hal/src/subghz/tcxo_mode.rs
@@ -44,7 +44,7 @@ impl core::fmt::Display for TcxoTrim {
 }
 
 impl TcxoTrim {
-    /// Get the value of the TXCO trim in millivolts.
+    /// Get the value of the TCXO trim in millivolts.
     ///
     /// # Example
     ///
@@ -113,11 +113,11 @@ impl TcxoMode {
     /// ```
     /// use stm32wlxx_hal::subghz::{TcxoMode, TcxoTrim};
     ///
-    /// const TCXO_MODE: TcxoMode = TcxoMode::new().set_txco_trim(TcxoTrim::Volts1pt6);
+    /// const TCXO_MODE: TcxoMode = TcxoMode::new().set_tcxo_trim(TcxoTrim::Volts1pt6);
     /// # assert_eq!(TCXO_MODE.as_slice()[1], 0x00);
     /// ```
-    #[must_use = "set_txco_trim returns a modified TcxoMode"]
-    pub const fn set_txco_trim(mut self, tcxo_trim: TcxoTrim) -> TcxoMode {
+    #[must_use = "set_tcxo_trim returns a modified TcxoMode"]
+    pub const fn set_tcxo_trim(mut self, tcxo_trim: TcxoTrim) -> TcxoMode {
         self.buf[1] = tcxo_trim as u8;
         self
     }
@@ -154,7 +154,7 @@ impl TcxoMode {
     /// use stm32wlxx_hal::subghz::{TcxoMode, TcxoTrim, Timeout};
     ///
     /// const TCXO_MODE: TcxoMode = TcxoMode::new()
-    ///     .set_txco_trim(TcxoTrim::Volts1pt7)
+    ///     .set_tcxo_trim(TcxoTrim::Volts1pt7)
     ///     .set_timeout(Timeout::from_raw(0x123456));
     /// assert_eq!(TCXO_MODE.as_slice(), &[0x97, 0x1, 0x12, 0x34, 0x56]);
     /// ```

--- a/lora-e5-bsp/src/lib.rs
+++ b/lora-e5-bsp/src/lib.rs
@@ -1,4 +1,4 @@
-//! seeed LoRa-E5 development kit board support package.
+//! Seeed LoRa-E5 development kit board support package.
 
 #![cfg_attr(not(test), no_std)]
 #![warn(missing_docs)]

--- a/testsuite/src/pka.rs
+++ b/testsuite/src/pka.rs
@@ -137,7 +137,7 @@ mod tests {
             defmt::info!("Approximate cycles per PKA p256 sign: {}", elapsed);
         }
 
-        // rust-crypto p256 for comparsion
+        // rust-crypto p256 for comparison
         {
             use ecdsa::hazmat::SignPrimitive;
             use p256::{elliptic_curve::ops::Reduce, Scalar};
@@ -216,7 +216,7 @@ mod tests {
             defmt::info!("Approximate cycles per PKA p256 verify: {}", elapsed);
         }
 
-        // rust-crypto p256 for comparsion
+        // rust-crypto p256 for comparison
         {
             use ecdsa::{hazmat::VerifyPrimitive, Signature};
             use p256::{elliptic_curve::ops::Reduce, PublicKey, Scalar};

--- a/testsuite/src/subghz.rs
+++ b/testsuite/src/subghz.rs
@@ -91,7 +91,7 @@ const PA_CONFIG: PaConfig = PaConfig::LP_10;
 const TX_PARAMS: TxParams = TxParams::LP_10.set_ramp_time(RampTime::Micros40);
 
 const TCXO_MODE: TcxoMode = TcxoMode::new()
-    .set_txco_trim(TcxoTrim::Volts1pt7)
+    .set_tcxo_trim(TcxoTrim::Volts1pt7)
     .set_timeout(Timeout::from_duration_sat(Duration::from_millis(10)));
 
 // WARNING will wrap-around eventually, use this for relative timing only
@@ -219,7 +219,7 @@ fn ping_pong(sg: &mut MySubghz, rng: &mut Rng, rfs: &mut RfSwitch, pkt: PacketTy
 
                 let (status, len, ptr) = unwrap!(sg.rx_buffer_status());
                 defmt::assert_eq!(len, DATA_LEN);
-                defmt::assert_eq!(status.cmd(), Ok(CmdStatus::Avaliable));
+                defmt::assert_eq!(status.cmd(), Ok(CmdStatus::Available));
                 defmt::assert_eq!(ptr, RX_BUF_OFFSET);
                 defmt::assert_eq!(irq_status, 0b10);
                 let mut data_buf: [u8; DATA_LEN as usize] = [0; DATA_LEN as usize];
@@ -251,7 +251,7 @@ fn ping_pong(sg: &mut MySubghz, rng: &mut Rng, rfs: &mut RfSwitch, pkt: PacketTy
                 return;
             } else {
                 defmt::assert_eq!(irq_status, 0);
-                defmt::assert_ne!(status.cmd(), Ok(CmdStatus::Avaliable));
+                defmt::assert_ne!(status.cmd(), Ok(CmdStatus::Available));
                 defmt::assert_ne!(status.cmd(), Ok(CmdStatus::ProcessingError));
                 defmt::assert_ne!(status.cmd(), Ok(CmdStatus::ExecutionFailure));
 


### PR DESCRIPTION
Addresses several spelling issues. Most are in comments. The two in programmatic interfaces are:
- Renamed function TcxoMode::set_txco_trim() to TcxoMode::set_tcxo_trim() to correct spelling.
- Renamed enum CmdStatus::Avaliable to CmdStatus::Available to correct spelling.
