### PR TITLE
subghz: Allow custom lora sync word

### DIFF
--- a/hal/src/subghz/lora_sync_word.rs
+++ b/hal/src/subghz/lora_sync_word.rs
@@ -9,7 +9,7 @@ pub enum LoRaSyncWord {
     /// LoRa public network.
     Public,
     /// Custom sync word
-    Custom([u8; 2])
+    Custom([u8; 2]),
 }
 
 impl LoRaSyncWord {

--- a/hal/src/subghz/lora_sync_word.rs
+++ b/hal/src/subghz/lora_sync_word.rs
@@ -8,6 +8,8 @@ pub enum LoRaSyncWord {
     Private,
     /// LoRa public network.
     Public,
+    /// Custom sync word
+    Custom([u8; 2])
 }
 
 impl LoRaSyncWord {
@@ -15,6 +17,7 @@ impl LoRaSyncWord {
         match self {
             LoRaSyncWord::Private => [0x14, 0x24],
             LoRaSyncWord::Public => [0x34, 0x44],
+            LoRaSyncWord::Custom(buf) => buf,
         }
     }
 }


### PR DESCRIPTION
Hi @newAM 

Firstly thanks again for your great effort for this library!

We are trying to use this library to implement a factory testing firmware for our LoRa products. The current implementation doesn't allow us to configure custom LoRa sync word, so our LoRa protocol won't work. Therefore I implemented this feature to make it fit to our use cases.

Regards,
Jackson