### PR TITLE
Fix SNR read.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a missing `must_use` in `SleepCfg::set_startup`.
+
 ### Changed
-- Renamed function TcxoMode::set_txco_trim() to TcxoMode::set_tcxo_trim() to correct spelling.
-- Renamed enum CmdStatus::Avaliable to CmdStatus::Available to correct spelling.
 - Updated minimum `chrono` version to `0.4.23` to satisfy `cargo-audit`.
 - Changed the edition from 2021 to 2024.
 - Changed minimum supported rust version from 1.60 to 1.85.
 
 ### Fixed
-- Added a missing `must_use` in `SleepCfg::set_startup`.
+- Fixed an incorrect cast from `u8` to `i16` in `LoRaPacketStatus::snr_pkt`
+- Renamed function `TcxoMode::set_txco_trim` to `TcxoMode::set_tcxo_trim` to fix spelling.
+- Renamed enum `CmdStatus::Avaliable` to `CmdStatus::Available` to fix spelling.
 
 ## [0.6.1] - 2022-08-01
 ### Fixed

--- a/hal/src/subghz/packet_status.rs
+++ b/hal/src/subghz/packet_status.rs
@@ -232,7 +232,7 @@ impl LoRaPacketStatus {
     /// assert_eq!(pkt_status.snr_pkt().to_integer(), 10);
     /// ```
     pub fn snr_pkt(&self) -> Ratio<i16> {
-        Ratio::new_raw(i16::from(self.buf[2]), 4)
+        Ratio::new_raw(i16::from(self.buf[2] as i8), 4)
     }
 
     /// Estimation of RSSI level of the LoRa signal after despreading.


### PR DESCRIPTION
It was giving wrong values, because the data from the radio is 2's compliment.

See table Table 13-80 in SX1262 datasheet.